### PR TITLE
Feature/disable failure on response incorrect format

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Any custom formatting function must return an object of the form:
 
 If the user-defined formatting function fails, then the original message/details will be returned (as if the function was never defined in the first place)
 
+The library also accepts some custom options in the form of `joi4expressOptions`, the optional 4th parameter to `joi4express`. These options include:
+- **failOnResponseMisformat** (default `true`): If false, the response will be returned even if its format validation fail. However, the `invalidResponseLogger` function will still be invoked if provided.
+- **invalidResponseLogger**: If provided, this function will be invoked with the formatted Joi error (including the formatting performed by a Custom Joi Error Formatting function) as well as the original Joi error.
+
 ## Installation
 
 ### Installing joi4express

--- a/README.md
+++ b/README.md
@@ -50,12 +50,29 @@ app.listen(port, function () {
 })
 ```
 
-The library also accepts a Joi Options object, and a Custom Joi Error Formatting function.
+The library also accepts a Joi Options object.
+
+### joi4express options
+Additionally, the library has some joi4express specific options in the form of `joi4expressOptions`. These options include:
+
+#### joiErrorFormatter
+Provides a custom format to the Joi errors. Any custom formatting function must return an object of the form:
+
+```js
+{
+  message: 'a message string',
+  details: [
+    {
+      // Joi Error Details Object
+    }
+  ]
+}
+```
 
 In the following example, double quotes will be removed due to the custom error formatting function.
 
 ```js
-const customJoiErrorFormatFcn = (e) => {
+const joiErrorFormatter = (e) => {
   const message = e.message.replace(/"/g, '')
   const details = e.details.map(detail => ({
     ...detail,
@@ -69,27 +86,16 @@ const customJoiErrorFormatFcn = (e) => {
 }
 
 const joiOptions = null // Or some desired options
-app.get('/', joi4express(helloWorld, joiOptions, customJoiErrorFormatFcn))
-```
-
-Any custom formatting function must return an object of the form:
-
-```js
- {
-  message: 'a message string',
-  details: [
-    {
-      // Joi Error Details Object
-    }
-  ]
-}
+app.get('/', joi4express(helloWorld, joiOptions, { joiErrorFormatter }))
 ```
 
 If the user-defined formatting function fails, then the original message/details will be returned (as if the function was never defined in the first place)
 
-The library also accepts some custom options in the form of `joi4expressOptions`, the optional 4th parameter to `joi4express`. These options include:
-- **failOnResponseMisformat** (default `true`): If false, the response will be returned even if its format validation fail. However, the `invalidResponseLogger` function will still be invoked if provided.
-- **invalidResponseLogger**: If provided, this function will be invoked with the formatted Joi error (including the formatting performed by a Custom Joi Error Formatting function) as well as the original Joi error.
+#### failOnResponseMisformat (default `true`)
+If false, the response will be returned even if its format validation fails. However, the `invalidResponseLogger` function will still be invoked if provided.
+
+#### invalidResponseLogger
+If provided, this function will be invoked with the formatted Joi error (including the formatting performed by `joiErrorFormatter`) as well as the original Joi error.
 
 ## Installation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ const Joi = require('joi')
  * @param {object} route.validate - The Joi's schema for the request
  * @param {object} route.response - The Joi's schema for the response
  * @param {object} options - Joi's options
- * @param {function} formatFcn - Optional function to format Joi Errors.
+ * @param {object} [joi4expressOptions] - Joi4express's options
+ * @param {function} [joi4expressOptions.joiErrorFormatter] - Optional function to format Joi Errors.
  *                             Must return an object of the form:
  *                             {
  *                               message: 'Some Joi error message',
@@ -19,15 +20,14 @@ const Joi = require('joi')
  *                                 }
  *                               ]
  *                             }
- * @param {object} [joi4expressOptions] - Joi4express's options
  * @param {object} [joi4expressOptions.failOnResponseMisformat=true] - If false, the response will be sent as if the response joi validation succeeded
  * @param {function} [joi4expressOptions.invalidResponseLogger] - Optional function to log response Joi error.
  *  It is provided the formatted error and the original Joi error.
  */
-module.exports = (route, options, formatFcn, { failOnResponseMisformat = true, invalidResponseLogger } = {}) => {
-  // If no formatFcn is provided, define a default behavior
+module.exports = (route, options, { joiErrorFormatter, failOnResponseMisformat = true, invalidResponseLogger } = {}) => {
+  // If no joiErrorFormatter is provided, define a default behavior
   // which doesn't modify the error data
-  formatFcn = formatFcn || (err => ({
+  joiErrorFormatter = joiErrorFormatter || (err => ({
     message: err.message,
     details: err.details
   }))
@@ -54,7 +54,7 @@ module.exports = (route, options, formatFcn, { failOnResponseMisformat = true, i
     let details
 
     try {
-      const formattedDetails = formatFcn(originalError)
+      const formattedDetails = joiErrorFormatter(originalError)
       message = formattedDetails.message
       details = formattedDetails.details
     } catch (e) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,12 @@ const Joi = require('joi')
  *                                 }
  *                               ]
  *                             }
+ * @param {object} [joi4expressOptions] - Joi4express's options
+ * @param {object} [joi4expressOptions.failOnResponseMisformat=true] - If false, the response will be sent as if the response joi validation succeeded
+ * @param {function} [joi4expressOptions.invalidResponseLogger] - Optional function to log response Joi error.
+ *  It is provided the formatted error and the original Joi error.
  */
-module.exports = (route, options, formatFcn) => {
+module.exports = (route, options, formatFcn, { failOnResponseMisformat = true, invalidResponseLogger } = {}) => {
   // If no formatFcn is provided, define a default behavior
   // which doesn't modify the error data
   formatFcn = formatFcn || (err => ({
@@ -87,7 +91,14 @@ module.exports = (route, options, formatFcn) => {
         function responseValidationDone (err) {
           if (err) {
             const { message, details } = handleError(err)
-            return next(Boom.badImplementation(message, details))
+
+            if (invalidResponseLogger) {
+              invalidResponseLogger({ message, details }, err)
+            }
+
+            if (failOnResponseMisformat) {
+              return next(Boom.badImplementation(message, details))
+            }
           }
 
           // Restoring it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joi4express",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joi4express",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,51 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.7.2",
+      "resolved": "https://artifactory/api/npm/npm/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha1-UF9Vx04CcrQ/bFLYGUa+1wWPwOI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory/api/npm/npm/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha1-KTZ0/MsyYqx4LHqt/eyoaxDHXEA=",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory/api/npm/npm/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha1-8T5xPLMxOxq5ZZAbAbCCjqa3cIk=",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://artifactory/api/npm/npm/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha1-hvIb2z1SSA+vCJKkgMmQaqWlKTg=",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://artifactory/api/npm/npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha1-jaXGUwkVZT86Hzj9XxAdjD+AecU=",
+      "dev": true
+    },
     "acorn": {
       "version": "6.2.1",
       "resolved": "https://artifactory.ubisoft.org/api/npm/npm-gap/acorn/-/acorn-6.2.1.tgz",
@@ -2006,6 +2051,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory/api/npm/npm/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha1-cnikAn2IlgFkDuDODloAuZJGfaQ=",
+      "dev": true
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://artifactory.ubisoft.org/api/npm/npm-gap/lcid/-/lcid-1.0.0.tgz",
@@ -2066,6 +2117,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://artifactory/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isfunction": {
@@ -2551,6 +2608,19 @@
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
+    "nise": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory/api/npm/npm/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha1-n3n/AvoALtX/vFOK1YUY+gEdyRM=",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -3016,6 +3086,23 @@
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory/api/npm/npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://artifactory/api/npm/npm/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://artifactory.ubisoft.org/api/npm/npm-gap/path-type/-/path-type-1.1.0.tgz",
@@ -3428,6 +3515,44 @@
       "resolved": "https://artifactory.ubisoft.org/api/npm/npm-gap/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://artifactory/api/npm/npm/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha1-uQF+JGM/SxyY37bnhKXwUJ9f2F0=",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://artifactory/api/npm/npm/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://artifactory/api/npm/npm/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mocha": "^6.2.0",
     "mochawesome": "^2.0.2",
     "nyc": "^14.1.1",
+    "sinon": "^9.0.2",
     "standard": "^12.0.1"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi4express",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Joi validator for express, validates the request and the reponse",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi4express",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Joi validator for express, validates the request and the reponse",
   "main": "lib/index.js",
   "scripts": {

--- a/test/unit/index/invalidate-response.js
+++ b/test/unit/index/invalidate-response.js
@@ -37,7 +37,7 @@ describe('#index', () => {
       throw new Error('This should not be called')
     }
   }
-  const formatFcn = (e) => {
+  const joiErrorFormatter = (e) => {
     const message = e.message.replace(/"/g, '')
     const details = e.details.map(detail => ({
       ...detail,
@@ -60,7 +60,7 @@ describe('#index', () => {
       response: responseSchema
     }
 
-    joi4express(route, joiOptions, null, { invalidResponseLogger })({}, response, (err) => {
+    joi4express(route, joiOptions, { invalidResponseLogger })({}, response, (err) => {
       expect(err).to.exist()
       sinon.assert.calledOnce(invalidResponseLogger)
 
@@ -77,7 +77,7 @@ describe('#index', () => {
       response: responseSchema
     }
 
-    joi4express(route, joiOptions, formatFcn)({}, response, (err) => {
+    joi4express(route, joiOptions, { joiErrorFormatter })({}, response, (err) => {
       expect(err).to.exist()
       expect(err.message).to.not.contain('"')
 
@@ -86,7 +86,7 @@ describe('#index', () => {
   })
 
   it('should invalidate a response (with 2xx expected status code) and should handle an invalid formatter string', (done) => {
-    const invalidMsgFormatter = '.01928398ad@#!'
+    const invalidJoiErrorFormatter = '.01928398ad@#!'
     const expectedStatusCode = 204
     const route = {
       handler: (req, res) => {
@@ -95,7 +95,7 @@ describe('#index', () => {
       response: responseSchema
     }
 
-    joi4express(route, joiOptions, invalidMsgFormatter)({}, response, (err) => {
+    joi4express(route, joiOptions, { joiErrorFormatter: invalidJoiErrorFormatter })({}, response, (err) => {
       expect(err).to.exist()
       expect(err.message).to.contain('"')
 

--- a/test/unit/index/invalidate-response.js
+++ b/test/unit/index/invalidate-response.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
+const sinon = require('sinon')
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 
@@ -50,6 +51,7 @@ describe('#index', () => {
   }
 
   it('should invalidate a response (with 2xx expected status code)', (done) => {
+    const invalidResponseLogger = sinon.stub()
     const expectedStatusCode = 204
     const route = {
       handler: (req, res) => {
@@ -58,8 +60,9 @@ describe('#index', () => {
       response: responseSchema
     }
 
-    joi4express(route, joiOptions)({}, response, (err) => {
+    joi4express(route, joiOptions, null, { invalidResponseLogger })({}, response, (err) => {
       expect(err).to.exist()
+      sinon.assert.calledOnce(invalidResponseLogger)
 
       done()
     })

--- a/test/unit/index/validate-response.js
+++ b/test/unit/index/validate-response.js
@@ -127,4 +127,30 @@ describe('#index', () => {
 
     joi4express(route)({}, response, done)
   })
+
+  it('should validate an invalid response if failOnResponseMisformat option is false', (done) => {
+    const expectedStatusCode = 204
+    const expectedOutput = { param2: 12 }
+    const response = {
+      status: (code) => {
+        response.statusCode = code
+
+        return response
+      },
+      send: (body) => {
+        expect(response.statusCode).to.equal(expectedStatusCode)
+        expect(body).to.equal(expectedOutput)
+
+        done()
+      }
+    }
+    const route = {
+      handler: (req, res) => {
+        res.status(expectedStatusCode).send(expectedOutput)
+      },
+      response: responseSchema
+    }
+
+    joi4express(route, null, null, { failOnResponseMisformat: false })({}, response, done)
+  })
 })

--- a/test/unit/index/validate-response.js
+++ b/test/unit/index/validate-response.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
+const sinon = require('sinon')
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 
@@ -129,6 +130,7 @@ describe('#index', () => {
   })
 
   it('should validate an invalid response if failOnResponseMisformat option is false', (done) => {
+    const invalidResponseLogger = sinon.stub()
     const expectedStatusCode = 204
     const expectedOutput = { param2: 12 }
     const response = {
@@ -140,6 +142,7 @@ describe('#index', () => {
       send: (body) => {
         expect(response.statusCode).to.equal(expectedStatusCode)
         expect(body).to.equal(expectedOutput)
+        sinon.assert.calledOnce(invalidResponseLogger)
 
         done()
       }
@@ -151,6 +154,6 @@ describe('#index', () => {
       response: responseSchema
     }
 
-    joi4express(route, null, null, { failOnResponseMisformat: false })({}, response, done)
+    joi4express(route, null, null, { failOnResponseMisformat: false, invalidResponseLogger })({}, response, done)
   })
 })

--- a/test/unit/index/validate-response.js
+++ b/test/unit/index/validate-response.js
@@ -154,6 +154,6 @@ describe('#index', () => {
       response: responseSchema
     }
 
-    joi4express(route, null, null, { failOnResponseMisformat: false, invalidResponseLogger })({}, response, done)
+    joi4express(route, null, { failOnResponseMisformat: false, invalidResponseLogger })({}, response, done)
   })
 })


### PR DESCRIPTION
We felt like causing the response to fail if the format does not fully match the provided response Joi model, although generally justified, was a bit too aggresive in some occasions. As such, this MR aims to add support for 2 new joi4express exclusive optional options.

The first one allows the user of the library to still return the expected response even if the validation fails.

A second option if a simple function that will be invoked in any situation where the response validation fails. As such, if a user wants to, instead of failing the response, simply log it, it can set the validation to false and provide a function responsible to log the error instead. This way, invalid responses can still be caught and acted upon by the development team, without causing more serious trouble on the client side.